### PR TITLE
dc-cal-errors default values

### DIFF
--- a/bin/pylal_cbc_cohptf_efficiency
+++ b/bin/pylal_cbc_cohptf_efficiency
@@ -195,19 +195,19 @@ def parse_command_line():
                      help="The standard deviation to use when calculating the "\
                           "V1 calibration amplitude error.")
   calopts.add_option("-p", "--h1-dc-cal-error", action="store",\
-                     type="float", default=0,
+                     type="float", default=1.0,
                      help="The scaling factor to use when calculating the H1 "\
                            "calibration amplitude error.")
   calopts.add_option("-P", "--h2-dc-cal-error", action="store",\
-                     type="float", default=0,
+                     type="float", default=1.0,
                      help="The scaling factor to use when calculating the H2 "\
                            "calibration amplitude error.")
   calopts.add_option( "-r", "--l1-dc-cal-error", action="store",\
-                     type="float", default=0,
+                     type="float", default=1.0,
                      help="The scaling factor to use when calculating the L1 "\
                            "calibration amplitude error.")
   calopts.add_option("-R", "--v1-dc-cal-error", action="store",\
-                     type="float", default=0,
+                     type="float", default=1.0,
                      help="The scaling factor to use when calculating the V1 "\
                            "calibration amplitude error.")
 


### PR DESCRIPTION
The max of dc-cal-errors ends up being an overall factor of a few denominators so it should default to 1.0 rather than 0 to have no effect.